### PR TITLE
Mkdirp the target directory if it doesn't exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 var recursiveCopy = require('recursive-copy')
+const mkdirp = require('mkdirp')
 
 function copy(bundler) {
   bundler.on('bundled', async bundle => {
@@ -55,6 +56,9 @@ function copy(bundler) {
 
     for (let i = 0; i < sourceArray.length; i++) {
       if (fs.existsSync(sourceArray[i])) {
+        if (!fs.existsSync(targetArray[i])) {
+          mkdirp.sync(targetArray[i])
+        }
         try {
           await recursiveCopy(sourceArray[i], targetArray[i], {
             overwrite: true

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "it is parcel plugin that copy static dir to target dir ",
   "main": "index.js",
   "dependencies": {
+    "mkdirp": "^0.5.1",
     "recursive-copy": "^2.0.9"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello! Thanks for writing this plugin, it's just what I needed as the alternative, `parcel-plugin-static-files-copy` doesn't allow setting a custom target directory.

However I wanted my SVGs to be copied to the subfolder `./dist/svg` - but as this folder didn't exist yet it wasn't working for me.

This change will create the target directory if it doesn't exist (however it will only do this if the source directory exists too)

Thanks again!